### PR TITLE
Set up Cursor Cloud dev environment (add AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single static **Astro** blog (`austinabbott.dev`, package name `dev-blog`), deployed to Cloudflare Pages. There is no backend, database, or other service — the only "service" is the Astro dev/build process. Commands are the npm scripts in `package.json` (`dev`/`start`, `build`, `preview`, `astro`).
+
+- Node: `.nvmrc` pins Node `24.18.0`, which is installed and set as the nvm default. A login shell (`bash -lc '...'`) picks up Node 24 automatically. Astro 6 also works on the base Node 22, so either is fine.
+- Run dev: `npm run dev` serves the site at `http://localhost:4321/` with hot reload. Editing/adding Markdown under `src/content/blog/` is the core "content authoring" flow and hot-reloads into the blog index and post pages.
+- Build: `npm run build` runs `astro check` (type check) first, then `astro build` into `dist/`. This is the closest thing to a lint step — there is **no ESLint/Prettier** configured, and there is **no test framework** (no test command exists).
+- Preview production build: `npm run preview` serves `dist/` (requires a prior build).
+- Non-obvious: `npm install` under npm 11+ prints a benign `allow-scripts` warning that `esbuild` and `sharp` install scripts were skipped. This does **not** break anything — `sharp` image optimization works via prebuilt `@img/sharp-*` platform packages, confirmed by a successful `npm run build`. Do not attempt interactive `npm approve-scripts`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the Cursor Cloud development environment for this Astro blog and documents non-obvious startup/run notes for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the single Astro dev/build service, commands, Node version, and the benign npm `allow-scripts` warning.

No application code was changed. The update script for VM startup is `npm install`.

## Verification
- `npm install` — dependencies installed (Node 24.18.0 via nvm; base Node 22 also works with Astro 6).
- `npm run build` — `astro check` type-check passed, static build completed (11 pages, sharp image optimization worked).
- `npm run dev` — dev server served at `http://localhost:4321/`; created a temporary Markdown post and confirmed it rendered on the home page, blog index, and post page (temporary post removed, not committed).

[astro_dev_blog_hello_world.mp4](https://cursor.com/agents/bc-058c1a3e-918d-47ff-b906-d901186342a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_dev_blog_hello_world.mp4)

[Blog index rendering new post](https://cursor.com/agents/bc-058c1a3e-918d-47ff-b906-d901186342a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_index.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-058c1a3e-918d-47ff-b906-d901186342a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-058c1a3e-918d-47ff-b906-d901186342a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

