### PR TITLE
Add lightweight dark mode with auto-detect and manual toggle

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -59,4 +59,53 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
 
+<script is:inline>
+  const THEME_KEY = "theme";
+
+  function getStoredTheme() {
+    try {
+      const stored = localStorage.getItem(THEME_KEY);
+      if (stored === "light" || stored === "dark") return stored;
+    } catch {}
+    return null;
+  }
+
+  function getSystemTheme() {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+
+  function getTheme() {
+    return getStoredTheme() ?? getSystemTheme();
+  }
+
+  function applyTheme(theme, persist = false) {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    if (persist) {
+      try {
+        localStorage.setItem(THEME_KEY, theme);
+      } catch {}
+    }
+  }
+
+  applyTheme(getTheme());
+
+  document.addEventListener("astro:before-swap", (event) => {
+    const theme = getTheme();
+    event.newDocument.documentElement.classList.toggle("dark", theme === "dark");
+  });
+
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", (event) => {
+      if (!getStoredTheme()) {
+        applyTheme(event.matches ? "dark" : "light");
+      }
+    });
+
+  window.__setTheme = (theme) => applyTheme(theme, true);
+  window.__getTheme = getTheme;
+</script>
+
 <ClientRouter />

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -61,23 +61,20 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
 
 <script is:inline>
   const THEME_KEY = "theme";
+  const colorScheme = window.matchMedia("(prefers-color-scheme: dark)");
 
   function getStoredTheme() {
     try {
       const stored = localStorage.getItem(THEME_KEY);
       if (stored === "light" || stored === "dark") return stored;
-    } catch {}
+    } catch {
+      // localStorage can throw in private browsing
+    }
     return null;
   }
 
-  function getSystemTheme() {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
-  }
-
   function getTheme() {
-    return getStoredTheme() ?? getSystemTheme();
+    return getStoredTheme() ?? (colorScheme.matches ? "dark" : "light");
   }
 
   function applyTheme(theme, persist = false) {
@@ -85,27 +82,34 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
     if (persist) {
       try {
         localStorage.setItem(THEME_KEY, theme);
-      } catch {}
+      } catch {
+        // localStorage can throw in private browsing
+      }
     }
   }
 
   applyTheme(getTheme());
 
   document.addEventListener("astro:before-swap", (event) => {
-    const theme = getTheme();
-    event.newDocument.documentElement.classList.toggle("dark", theme === "dark");
+    event.newDocument.documentElement.classList.toggle(
+      "dark",
+      getTheme() === "dark",
+    );
   });
 
-  window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", (event) => {
-      if (!getStoredTheme()) {
-        applyTheme(event.matches ? "dark" : "light");
-      }
-    });
+  const handleSystemThemeChange = (event) => {
+    if (!getStoredTheme()) {
+      applyTheme(event.matches ? "dark" : "light");
+    }
+  };
+
+  if (typeof colorScheme.addEventListener === "function") {
+    colorScheme.addEventListener("change", handleSystemThemeChange);
+  } else {
+    colorScheme.addListener(handleSystemThemeChange);
+  }
 
   window.__setTheme = (theme) => applyTheme(theme, true);
-  window.__getTheme = getTheme;
 </script>
 
 <ClientRouter />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import HeaderLink from "./HeaderLink.astro";
+import ThemeToggle from "./ThemeToggle.astro";
 ---
 
 <header transition:persist="site-header">
@@ -20,6 +21,7 @@ import HeaderLink from "./HeaderLink.astro";
       <HeaderLink href="/about">About</HeaderLink>
     </div>
     <div class="social-links" id="SocialLinks">
+      <ThemeToggle />
       <a href="https://github.com/AustinAbbott" target="_blank" rel="noopener noreferrer">
         <span class="sr-only">Go to Austin Abbott's GitHub</span>
         <svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
@@ -76,7 +78,7 @@ import HeaderLink from "./HeaderLink.astro";
   header {
     margin: 0;
     padding: 0 1em;
-    background: white;
+    background: var(--surface);
     box-shadow: 0 2px 8px rgba(var(--black), 5%);
   }
 
@@ -105,7 +107,7 @@ import HeaderLink from "./HeaderLink.astro";
 
   nav a {
     padding: 1em 0.5em;
-    color: var(--black);
+    color: rgb(var(--black));
     border-bottom: 4px solid transparent;
     text-decoration: none;
   }
@@ -113,6 +115,10 @@ import HeaderLink from "./HeaderLink.astro";
   nav a.active {
     text-decoration: none;
     border-bottom-color: var(--accent);
+  }
+
+  .social-links {
+    gap: 0.25rem;
   }
 
   .social-links a {

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,112 @@
+<button
+  id="theme-toggle"
+  type="button"
+  aria-label="Switch to dark mode"
+  aria-pressed="false"
+>
+  <svg
+    class="sun-icon"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <svg
+    class="moon-icon"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
+<script>
+  function updateToggleState() {
+    const isDark = document.documentElement.classList.contains("dark");
+    const button = document.getElementById("theme-toggle");
+
+    if (!button) return;
+
+    button.setAttribute("aria-pressed", String(isDark));
+    button.setAttribute(
+      "aria-label",
+      isDark ? "Switch to light mode" : "Switch to dark mode",
+    );
+  }
+
+  function handleToggle() {
+    const isDark = document.documentElement.classList.contains("dark");
+    window.__setTheme?.(isDark ? "light" : "dark");
+    updateToggleState();
+  }
+
+  function setupThemeToggle() {
+    const button = document.getElementById("theme-toggle");
+    button?.addEventListener("click", handleToggle);
+    updateToggleState();
+  }
+
+  document.addEventListener("astro:page-load", setupThemeToggle);
+</script>
+
+<style>
+  #theme-toggle {
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    color: rgb(var(--black));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition:
+      background-color 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  #theme-toggle:hover {
+    background-color: rgb(var(--gray-light));
+    transform: scale(1.05);
+  }
+
+  #theme-toggle .sun-icon {
+    display: none;
+  }
+
+  #theme-toggle .moon-icon {
+    display: block;
+  }
+
+  :global(html.dark) #theme-toggle .sun-icon {
+    display: block;
+  }
+
+  :global(html.dark) #theme-toggle .moon-icon {
+    display: none;
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,80 +1,93 @@
-<button
-  id="theme-toggle"
-  type="button"
-  aria-label="Switch to dark mode"
-  aria-pressed="false"
->
-  <svg
-    class="sun-icon"
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <circle cx="12" cy="12" r="5"></circle>
-    <line x1="12" y1="1" x2="12" y2="3"></line>
-    <line x1="12" y1="21" x2="12" y2="23"></line>
-    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-    <line x1="1" y1="12" x2="3" y2="12"></line>
-    <line x1="21" y1="12" x2="23" y2="12"></line>
-    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-  </svg>
-  <svg
-    class="moon-icon"
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-  </svg>
-</button>
+<theme-toggle>
+  <button type="button" aria-label="Dark mode" aria-pressed="false">
+    <svg
+      class="sun-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="5"></circle>
+      <line x1="12" y1="1" x2="12" y2="3"></line>
+      <line x1="12" y1="21" x2="12" y2="23"></line>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+      <line x1="1" y1="12" x2="3" y2="12"></line>
+      <line x1="21" y1="12" x2="23" y2="12"></line>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+    <svg
+      class="moon-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+    </svg>
+  </button>
+</theme-toggle>
 
 <script>
-  function updateToggleState() {
-    const isDark = document.documentElement.classList.contains("dark");
-    const button = document.getElementById("theme-toggle");
+  class ThemeToggle extends HTMLElement {
+    observer?: MutationObserver;
 
-    if (!button) return;
+    constructor() {
+      super();
+      this.querySelector("button")?.addEventListener("click", () => {
+        const isDark = document.documentElement.classList.contains("dark");
+        window.__setTheme?.(isDark ? "light" : "dark");
+      });
+    }
 
-    button.setAttribute("aria-pressed", String(isDark));
-    button.setAttribute(
-      "aria-label",
-      isDark ? "Switch to light mode" : "Switch to dark mode",
-    );
+    connectedCallback() {
+      this.updateState();
+      this.observer = new MutationObserver(() => this.updateState());
+      this.observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
+      });
+    }
+
+    disconnectedCallback() {
+      this.observer?.disconnect();
+    }
+
+    updateState() {
+      const button = this.querySelector("button");
+      if (!button) return;
+
+      button.setAttribute(
+        "aria-pressed",
+        String(document.documentElement.classList.contains("dark")),
+      );
+    }
   }
 
-  function handleToggle() {
-    const isDark = document.documentElement.classList.contains("dark");
-    window.__setTheme?.(isDark ? "light" : "dark");
-    updateToggleState();
+  if (!customElements.get("theme-toggle")) {
+    customElements.define("theme-toggle", ThemeToggle);
   }
-
-  function setupThemeToggle() {
-    const button = document.getElementById("theme-toggle");
-    button?.addEventListener("click", handleToggle);
-    updateToggleState();
-  }
-
-  document.addEventListener("astro:page-load", setupThemeToggle);
 </script>
 
 <style>
-  #theme-toggle {
+  theme-toggle {
+    display: flex;
+  }
+
+  button {
     border: none;
     background: none;
     cursor: pointer;
@@ -89,24 +102,24 @@
       transform 0.2s ease;
   }
 
-  #theme-toggle:hover {
+  button:hover {
     background-color: rgb(var(--gray-light));
     transform: scale(1.05);
   }
 
-  #theme-toggle .sun-icon {
+  .sun-icon {
     display: none;
   }
 
-  #theme-toggle .moon-icon {
+  .moon-icon {
     display: block;
   }
 
-  :global(html.dark) #theme-toggle .sun-icon {
+  :global(html.dark) .sun-icon {
     display: block;
   }
 
-  :global(html.dark) #theme-toggle .moon-icon {
+  :global(html.dark) .moon-icon {
     display: none;
   }
 </style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,5 +3,4 @@
 
 interface Window {
   __setTheme?: (theme: "light" | "dark") => void;
-  __getTheme?: () => "light" | "dark";
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,7 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+interface Window {
+  __setTheme?: (theme: "light" | "dark") => void;
+  __getTheme?: () => "light" | "dark";
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,7 +28,6 @@ html.dark {
 	--gray-dark: 203, 213, 225;
 	--bg: #0b0d12;
 	--surface: #151a21;
-	--gray-gradient: rgba(var(--gray-light), 50%), var(--bg);
 	--box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.35),
 		0 16px 32px rgba(0, 0, 0, 0.3);
 	color-scheme: dark;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,9 +11,27 @@
 	--gray: 96, 115, 159;
 	--gray-light: 229, 233, 240;
 	--gray-dark: 34, 41, 57;
-	--gray-gradient: rgba(var(--gray-light), 50%), #fff;
+	--bg: #ffffff;
+	--surface: #ffffff;
+	--gray-gradient: rgba(var(--gray-light), 50%), var(--bg);
 	--box-shadow: 0 2px 6px rgba(var(--gray), 25%), 0 8px 24px rgba(var(--gray), 33%),
 		0 16px 32px rgba(var(--gray), 33%);
+	color-scheme: light;
+}
+
+html.dark {
+	--accent: #5c6fff;
+	--accent-dark: #8b97ff;
+	--black: 248, 250, 252;
+	--gray: 148, 163, 184;
+	--gray-light: 30, 41, 59;
+	--gray-dark: 203, 213, 225;
+	--bg: #0b0d12;
+	--surface: #151a21;
+	--gray-gradient: rgba(var(--gray-light), 50%), var(--bg);
+	--box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.35),
+		0 16px 32px rgba(0, 0, 0, 0.3);
+	color-scheme: dark;
 }
 @font-face {
 	font-family: 'Atkinson';
@@ -34,7 +52,9 @@ body {
 	margin: 0;
 	padding: 0;
 	text-align: left;
-	background: linear-gradient(var(--gray-gradient)) no-repeat;
+	background-color: var(--bg);
+	background-image: linear-gradient(var(--gray-gradient));
+	background-repeat: no-repeat;
 	background-size: 100% 600px;
 	word-wrap: break-word;
 	overflow-wrap: break-word;


### PR DESCRIPTION
## Summary
- Add `html.dark` CSS variable overrides in `global.css` for background, surface, text, and accent tokens
- Add a blocking inline theme script in `BaseHead.astro` for FOUC-free auto-detect from `prefers-color-scheme`, with `astro:before-swap` persistence for ClientRouter navigations
- Add a header `ThemeToggle` button that persists manual light/dark choice in `localStorage`

## Test plan
- [x] `npm run build` passes
- [x] First visit follows OS `prefers-color-scheme` (verified in Cursor browser)
- [x] Manual toggle switches theme and persists after reload
- [x] Theme stays consistent across Home → Blog → About navigations
- [x] Clearing `localStorage.theme` falls back to system preference


Made with [Cursor](https://cursor.com)