### PR TITLE
chore: Astro 7 upgrade hygiene (zod + AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,10 @@
 
 This repo is a single static **Astro** blog (`austinabbott.dev`, package name `dev-blog`), deployed to Cloudflare Pages. There is no backend, database, or other service — the only "service" is the Astro dev/build process. Commands are the npm scripts in `package.json` (`dev`/`start`, `build`, `preview`, `astro`).
 
-- Node: `.nvmrc` pins Node `24.18.0`, which is installed and set as the nvm default. A login shell (`bash -lc '...'`) picks up Node 24 automatically. Astro 6 also works on the base Node 22, so either is fine.
+- Node: `.nvmrc` pins Node `24.18.0`, which is installed and set as the nvm default. A login shell (`bash -lc '...'`) picks up Node 24 automatically. Astro 7 also works on the base Node 22, so either is fine.
 - Run dev: `npm run dev` serves the site at `http://localhost:4321/` with hot reload. Editing/adding Markdown under `src/content/blog/` is the core "content authoring" flow and hot-reloads into the blog index and post pages.
-- Build: `npm run build` runs `astro check` (type check) first, then `astro build` into `dist/`. This is the closest thing to a lint step — there is **no ESLint/Prettier** configured, and there is **no test framework** (no test command exists).
+- Build: `npm run build` runs `astro check` (type check) first, then `astro build` into `dist/`. This is the closest thing to a lint step — there is **no ESLint/Prettier** configured.
+- Visual regression: `npm run test:visual` runs Playwright screenshot comparisons against baselines in `tests/visual.spec.ts-snapshots/` (requires a prior Chromium install via `npx playwright install chromium`). Update baselines with `npm run test:visual:update`.
 - Preview production build: `npm run preview` serves `dist/` (requires a prior build).
 - Non-obvious: `npm install` under npm 11+ prints a benign `allow-scripts` warning that `esbuild` and `sharp` install scripts were skipped. This does **not** break anything — `sharp` image optimization works via prebuilt `@img/sharp-*` platform packages, confirmed by a successful `npm run build`. Do not attempt interactive `npm approve-scripts`.
+- Astro 7 notes for this project: no remark/rehype plugins (Sätteri default Markdown processor is fine), no `src/fetch.ts`, and content schemas should import `z` from `astro/zod` (not `astro:content`).

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const blog = defineCollection({
 	loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up for #198 after verifying the Astro 7 monorepo upgrade.

- Import content collection schemas from `astro/zod` instead of the deprecated `z` from `astro:content`
- Refresh `AGENTS.md` for Astro 7 (Sätteri notes, visual test commands)

Verified locally: `npm run build` and all 8 Playwright visual snapshots pass. Could not push directly to `renovate/major-astro-monorepo` (existing-branch status checks / Code Scanning), so this targets that branch instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-134922d5-31f1-4b9c-b5f8-cc244c298e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-134922d5-31f1-4b9c-b5f8-cc244c298e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

